### PR TITLE
feat/rtk mock store implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "rtk-mock-store",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "@reduxjs/toolkit": "^2.5.1"
+      },
       "devDependencies": {
         "@eslint/compat": "^1.2.6",
         "@eslint/eslintrc": "^3.2.0",
@@ -1839,6 +1842,30 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.5.1.tgz",
+      "integrity": "sha512-UHhy3p0oUpdhnSxyDjaRDYaw8Xra75UiLbCiRozVPHjfDwNYkh0TsVm/1OmTW8Md+iDAJmYPWUKMvsMc2GtpNg==",
+      "license": "MIT",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -4698,6 +4725,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6947,6 +6984,21 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -7000,6 +7052,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
     "tsup": "^8.3.6",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.24.0"
+  },
+  "dependencies": {
+    "@reduxjs/toolkit": "^2.5.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,37 @@
 import { createAsyncThunk, ReducersMapObject, Action, ThunkAction } from '@reduxjs/toolkit'
 
+/**
+ * Action type defintions for actions dispatched from createAsyncThunk.
+ * Need to stub the types here to properly check the action type in mock
+ * store's runThunk function to ensure complete type safety.
+ */
 type CreateAsyncThunkAction = ReturnType<typeof createAsyncThunk>
 type AsyncThunkAction = ReturnType<CreateAsyncThunkAction>
 
+/**
+ * Data structures and methods of a mock store.
+ *
+ * @typeParam MockRootState The root state of the mock store.
+ *
+ * @property rootStateSnapshots         The snapshots of the root state of the mock store.
+ * @property rootState                  The root state of the mock store.
+ * @property extraArgument              The extra argument of the mock store.
+ * @property getRootState               Returns the root state of the mock store.
+ * @property getReducerState            Returns the state of the reducer being tested.
+ * @property setRootState               Sets the root state of the mock store.
+ * @property setReducerState            Sets the state of the reducer being tested.
+ * @property getRootStateSnapshots      Returns the snapshots of the root state of the mock store.
+ * @property getRootStateSnapshot       Returns the snapshot of the root state of the mock store for a specific action type.
+ * @property getReducerStateSnapshots   Returns the snapshots of the reducer being tested.
+ * @property getReducerStateSnapshot    Returns the snapshot of the reducer being tested for a specific action type.
+ * @property printReducerStateSnapshots Prints the snapshots of the reducer being tested.
+ * @property printRootStateSnapshots    Prints the snapshots of the root state of the mock store.
+ * @property next                       The next middleware function.
+ * @property runThunk                   Runs a thunk action.
+ * @property getState                   Returns the root state of the mock store.
+ * @property dispatch                   Dispatches an action to the mock store.
+ * @property reset                      Resets the mock store state to intialRootState.
+ */
 type RTKMockStore<MockRootState> = {
   rootStateSnapshots: Record<Action['type'], MockRootState>[]
   rootState: MockRootState
@@ -26,11 +55,54 @@ type RTKMockStore<MockRootState> = {
   reset: () => void
 }
 
+/**
+ * Creates a mock store for testing redux actions and reducers using redux-toolkit.
+ * Can be used to test a single reducer in isolation or multiple reducers together.
+ *
+ * Note: Typings for root state and actions are inferred if using redux-toolkit slices,
+ * so its strongly recommended to use redux-toolkit slices for reducers and actions.
+ *
+ * @typeParam MockRootState The root state of the mock store.
+ *
+ * @param reducerToTest     The reducer to test.
+ * @param reducers          All reducers in the store.
+ * @param initialRootState  The initial state of the store.
+ *
+ * @returns A mock store.
+ *
+ * @example
+ * // __tests__/reducer.test.ts
+ * import createMockStore from 'rtk-mock-store';
+ * import { INITIAL_STATE, reducer, testAction } from './reducer';
+ *
+ * const mockStore = createMockStore(
+ *   'reducerToTest',
+ *   { reducerToTest: reducer },
+ *   { reducerToTest: INITIAL_STATE },
+ * );
+ *
+ * describe('reducerToTest', () => {
+ *   afterEach(() => {
+ *     mockStore.reset();
+ *   });
+ *
+ *   it('should have initial state', () => {
+ *     expect(mockStore.getReducerState()).toEqual({ test: false });
+ *   });
+ *   it('should set test to true', () => {
+ *     mockStore.dispatch(testAction());
+ *     expect(mockStore.dispatch.mock.calls[0][0].type).toEqual('reducerToTest/TEST_ACTION');
+ *     expect(mockStore.getReducerState()).toEqual({ test: true });
+ *   });
+ * });
+ */
 export default function createMockStore<MockRootState extends object>(
   reducerToTest: keyof MockRootState,
   reducers: ReducersMapObject<MockRootState, Action>,
   initialRootState: MockRootState,
 ): RTKMockStore<MockRootState> {
+  /* Middleware Types */
+
   type ThunkMiddlewareAction = ThunkAction<unknown, MockRootState, {}, Action>
   type ThunkMiddlewareProps = {
     dispatch: (action: ThunkMiddlewareAction) => void
@@ -38,6 +110,8 @@ export default function createMockStore<MockRootState extends object>(
     extraArgument: {}
   }
   type NextAction = (action: Action) => void
+
+  /* Middleware Mock */
 
   const thunkMiddleware =
     ({ dispatch, getState }: ThunkMiddlewareProps) =>
@@ -48,6 +122,8 @@ export default function createMockStore<MockRootState extends object>(
       }
       return next(action)
     }
+
+  /* Store Mock */
 
   const store: RTKMockStore<MockRootState> = {
     rootState: { ...initialRootState },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,122 @@
+import { createAsyncThunk, ReducersMapObject, Action, ThunkAction } from '@reduxjs/toolkit'
+
+type CreateAsyncThunkAction = ReturnType<typeof createAsyncThunk>
+type AsyncThunkAction = ReturnType<CreateAsyncThunkAction>
+
+type RTKMockStore<MockRootState> = {
+  rootStateSnapshots: Record<Action['type'], MockRootState>[]
+  rootState: MockRootState
+  extraArgument: object
+  getRootState: () => MockRootState
+  getReducerState: () => MockRootState[keyof MockRootState]
+  setRootState: (state: MockRootState) => void
+  setReducerState: (state: MockRootState[keyof MockRootState]) => void
+  getRootStateSnapshots: () => Record<Action['type'], MockRootState>[]
+  getRootStateSnapshot: (actionType: Action['type']) => Record<Action['type'], MockRootState> | undefined
+  getReducerStateSnapshots: () => Record<Action['type'], MockRootState[keyof MockRootState]>[]
+  getReducerStateSnapshot: (
+    actionType: Action['type'],
+  ) => Record<Action['type'], MockRootState[keyof MockRootState]> | undefined
+  printReducerStateSnapshots: () => void
+  printRootStateSnapshots: () => void
+  next: jest.Mock
+  runThunk: (action: AsyncThunkAction) => void
+  getState: () => MockRootState
+  dispatch: jest.Mock
+  reset: () => void
+}
+
+export default function createMockStore<MockRootState extends object>(
+  reducerToTest: keyof MockRootState,
+  reducers: ReducersMapObject<MockRootState, Action>,
+  initialRootState: MockRootState,
+): RTKMockStore<MockRootState> {
+  type ThunkMiddlewareAction = ThunkAction<unknown, MockRootState, {}, Action>
+  type ThunkMiddlewareProps = {
+    dispatch: (action: ThunkMiddlewareAction) => void
+    getState: () => MockRootState
+    extraArgument: {}
+  }
+  type NextAction = (action: Action) => void
+
+  const thunkMiddleware =
+    ({ dispatch, getState }: ThunkMiddlewareProps) =>
+    (next: NextAction) =>
+    (action: AsyncThunkAction) => {
+      if (typeof action === 'function') {
+        return action(dispatch, getState, {})
+      }
+      return next(action)
+    }
+
+  const store: RTKMockStore<MockRootState> = {
+    rootState: { ...initialRootState },
+    extraArgument: {},
+
+    getRootState: () => store.rootState,
+    getReducerState: () => store.rootState[reducerToTest],
+
+    setRootState: (state: MockRootState) => {
+      Object.assign(store.rootState, state)
+    },
+    setReducerState: (state: MockRootState[keyof MockRootState]) => {
+      store.rootState[reducerToTest] = state
+    },
+
+    next: jest.fn(),
+    runThunk: (action: AsyncThunkAction) => {
+      return thunkMiddleware(store)(store.next)(action)
+    },
+
+    getState: () => store.getRootState(),
+    dispatch: jest.fn((action: Action) => {
+      for (const reducerName in reducers) {
+        if (typeof action === 'function') {
+          return store.runThunk(action)
+        }
+        const reducer = reducers[reducerName]
+        store.rootState = {
+          ...store.rootState,
+          [reducerName]: {
+            // @ts-ignore
+            ...reducer(store.rootState[reducerName], action),
+          },
+        }
+        store.rootStateSnapshots.push({
+          [action.type]: { ...store.rootState },
+        })
+      }
+    }),
+
+    rootStateSnapshots: [],
+
+    getRootStateSnapshots: () => store.rootStateSnapshots,
+    getRootStateSnapshot: (actionType: Action['type']) =>
+      store.getRootStateSnapshots().find(snapshot => snapshot[actionType]),
+
+    getReducerStateSnapshots: () =>
+      store.rootStateSnapshots.map(snapshot => {
+        const keys = Object.keys(snapshot)
+        return keys.reduce((acc, key) => ({ ...acc, [key]: snapshot[key][reducerToTest] }), {})
+      }),
+    getReducerStateSnapshot: (actionType: Action['type']) =>
+      store.getReducerStateSnapshots().find(snapshot => snapshot[actionType]),
+
+    printRootStateSnapshots: () => {
+      console.log(JSON.stringify(store.getRootStateSnapshots(), null, 2))
+    },
+    printReducerStateSnapshots: () => {
+      console.log(JSON.stringify(store.getReducerStateSnapshots(), null, 2))
+    },
+
+    reset: () => {
+      store.rootStateSnapshots = []
+      store.rootState = { ...initialRootState }
+
+      store.next.mockClear()
+      store.dispatch.mockClear()
+    },
+  }
+
+  return store
+}


### PR DESCRIPTION
## Description

create a new factory function that will generate a jest compliant redux mock store. store should provide the following functional requirements:

- support type inference from store reducers and state
- support async action types (thunk middleware)
- support testing multiple reducers
- support methods for tracing dispatch actions and state changes

## Notes
 include cleanup function to best support jest testing lifecycle

closes #3 