### PR TITLE
docs/rtk mock store implementation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,8 @@ jobs:
         run: npm ci
       - name: Lint
         run: npm run lint
-      - name: Build
-        run: npm run build
-      - name: Link
-        run: npm link rtk-mock-store
       - name: Test
         run: npm run test:coverage
+      - name: Build
+        run: npm run build
   

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,10 @@ jobs:
         run: npm ci
       - name: Lint
         run: npm run lint
-      - name: Test
-        run: npm run test:coverage
       - name: Build
         run: npm run build
+      - name: Link
+        run: npm link rtk-mock-store
+      - name: Test
+        run: npm run test:coverage
   

--- a/README.md
+++ b/README.md
@@ -1,2 +1,85 @@
-# rtk-mock-store
+# rtk-mock-store ![build-workflow](https://github.com/davidsalman/rtk-mock-store/actions/workflows/build.yml/badge.svg) ![check-code-coverage](https://img.shields.io/badge/code--coverage-100%25-brightgreen)
 Modern redux store jest mock helper function for testing reducers using @reduxjs/toolkit slices.
+
+## Installation
+To install the `rtk-mock-store` package, use the following command:
+
+```sh
+npm install rtk-mock-store
+```
+
+## Examples
+
+* [simple reducer](https://github.com/davidsalman/rtk-mock-store/blob/main/examples/simpleSlice/__tests__/reducer.test.ts)
+* [async reducer](https://github.com/davidsalman/rtk-mock-store/blob/main/examples/asyncSlice/__tests__/reducer.test.ts)
+
+
+## API Documentation
+#### createMockStore
+Creates a mock store for testing redux actions and reducers using redux-toolkit. It can be used to test a single reducer in isolation or multiple reducers together.
+
+###### Type Parameters
+- `MockRootState`: The root state of the mock store.
+###### Parameters
+- `reducerToTest`: The reducer to test (key of `MockRootState`).
+- `reducers`: All reducers in the store (`ReducersMapObject`).
+- `initialRootState`: The initial state of the store (`MockRootState`).
+###### Returns
+- `RTKMockStore<MockRootState>`: The mock store instance.
+
+###### Example
+
+```typescript
+// reducer.test.ts
+import createMockStore from 'rtk-mock-store';
+import { INITIAL_STATE, reducer, testAction } from './reducer';
+
+const mockStore = createMockStore(
+  'reducerToTest',
+  { reducerToTest: reducer },
+  { reducerToTest: INITIAL_STATE }
+);
+
+describe('reducerToTest', () => {
+  afterEach(() => {
+    mockStore.reset();
+  });
+
+  it('should have initial state', () => {
+    expect(mockStore.getReducerState()).toEqual({ test: false });
+  });
+
+  it('should set test to true', () => {
+    mockStore.dispatch(testAction());
+    expect(mockStore.dispatch.mock.calls[0][0].type).toEqual('reducerToTest/TEST_ACTION');
+    expect(mockStore.getReducerState()).toEqual({ test: true });
+  });
+});
+```
+
+#### RTKMockStore Properties
+
+|Property|Type|Comments|
+|-|-|-|
+|`rootStateSnapshots`|`Record<Action['type'], MockRootState>[]`|The snapshots of the root state of the mock store.|
+|`rootState`|`MockRootState`|The root state of the mock store.|
+|`extraArgument`|object|The extra argument of the mock store.|
+|`getRootState`|() => `MockRootState`|Returns the root state of the mock store.|
+|`getReducerState`|() => `MockRootState[keyof MockRootState]`|Returns the state of the reducer being tested.|
+|`setRootState`|(state: `MockRootState`) => void|Sets the root state of the mock store.|
+|`setReducerState`|(state: `MockRootState[keyof MockRootState]`) => void|Sets the state of the reducer being tested.|
+|`getRootStateSnapshots`|() => `Record<Action['type'], MockRootState>[]`|Returns the snapshots of the root state of the mock store.|
+|`getRootStateSnapshot`|(actionType: `Action['type']`) => `Record<Action['type'], MockRootState> \| undefined`|Returns the snapshot of the root state of the mock store for a specific action type.|
+|`getReducerStateSnapshots`|() => `Record<Action['type'], MockRootState[keyof MockRootState]>[]`|Returns the snapshots of the reducer being tested.|
+|`getReducerStateSnapshot`|(actionType: `Action['type']`) => `Record<Action['type'], MockRootState[keyof MockRootState]> \| undefined`|Returns the snapshot of the reducer being tested for a specific action type.|
+|`printReducerStateSnapshots`|() => void|Prints the snapshots of the reducer being tested.|
+|`printRootStateSnapshots`|() => void|Prints the snapshots of the root state of the mock store.|
+|`next`|(action: `Action`) => void|The next middleware function.|
+|`runThunk`|(action: `ThunkAction<any, MockRootState, any, Action>`) => void|Runs a thunk action.|
+|`getState`|() => `MockRootState`|Returns the root state of the mock store.|
+|`dispatch`|(action: `Action`) => void|Dispatches an action to the mock store.|
+|`reset`|() => void|Resets the mock store state to intialRootState.|
+
+## Contribution
+
+If you want to contribute to this project, send a PR directly instead of creating an issue.

--- a/examples/asyncSlice/__tests__/reducer.test.ts
+++ b/examples/asyncSlice/__tests__/reducer.test.ts
@@ -1,0 +1,25 @@
+import createMockStore from 'rtk-mock-store'
+import reducer, { fetchData, initialState } from '../reducer'
+
+const mockStore = createMockStore('asyncSlice', { asyncSlice: reducer }, { asyncSlice: initialState })
+
+describe('async reducer', () => {
+  afterEach(() => {
+    mockStore.reset()
+  })
+
+  it('should have initial state', () => {
+    expect(mockStore.getReducerState()).toEqual({ data: [], error: null, loading: false })
+  })
+
+  it('should fetch data', async () => {
+    await mockStore.dispatch(fetchData())
+    expect(mockStore.dispatch.mock.calls[1][0].type).toEqual(fetchData.pending.type)
+    expect(mockStore.dispatch.mock.calls[2][0].type).toEqual(fetchData.fulfilled.type)
+    expect(mockStore.getReducerState()).toEqual({
+      data: mockStore.dispatch.mock.calls[2][0].payload,
+      error: null,
+      loading: false,
+    })
+  })
+})

--- a/examples/asyncSlice/reducer.ts
+++ b/examples/asyncSlice/reducer.ts
@@ -1,0 +1,52 @@
+import { createSlice, createAsyncThunk, SerializedError } from '@reduxjs/toolkit'
+
+interface Todo {
+  userId: number
+  id: number
+  title: string
+  completed: boolean
+}
+
+type AsyncState = {
+  data: Todo[]
+  error: SerializedError | null
+  loading: boolean
+}
+
+export const initialState: AsyncState = {
+  data: [],
+  loading: false,
+  error: null,
+}
+
+export const fetchData = createAsyncThunk('asyncSlice/fetchData', async () => {
+  try {
+    const response = await fetch('https://jsonplaceholder.typicode.com/todos')
+    return await response.json()
+  } catch (error) {
+    return error
+  }
+})
+
+const asyncSlice = createSlice({
+  name: 'asyncSlice',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(fetchData.pending, state => {
+        state.loading = true
+        state.error = null
+      })
+      .addCase(fetchData.fulfilled, (state, action) => {
+        state.loading = false
+        state.data = action.payload
+      })
+      .addCase(fetchData.rejected, (state, action) => {
+        state.loading = false
+        state.error = action.error
+      })
+  },
+})
+
+export default asyncSlice.reducer

--- a/examples/simpleSlice/__tests__/reducer.test.ts
+++ b/examples/simpleSlice/__tests__/reducer.test.ts
@@ -1,0 +1,35 @@
+import createMockStore from 'rtk-mock-store'
+import reducer, { initialState, decrement, increment, incrementByAmount } from '../reducer'
+
+const mockStore = createMockStore('simpleSlice', { simpleSlice: reducer }, { simpleSlice: initialState })
+
+describe('simple reducer', () => {
+  afterEach(() => {
+    mockStore.reset()
+  })
+
+  it('should have initial state', () => {
+    expect(mockStore.getReducerState()).toEqual({ value: 0 })
+  })
+
+  it('should increment', () => {
+    mockStore.dispatch(increment())
+    expect(mockStore.dispatch.mock.calls[0][0].type).toEqual(increment.type)
+    expect(mockStore.dispatch.mock.calls[0][0].payload).toBeUndefined()
+    expect(mockStore.getReducerState()).toEqual({ value: 1 })
+  })
+
+  it('should decrement', () => {
+    mockStore.dispatch(decrement())
+    expect(mockStore.dispatch.mock.calls[0][0].type).toEqual(decrement.type)
+    expect(mockStore.dispatch.mock.calls[0][0].payload).toBeUndefined()
+    expect(mockStore.getReducerState()).toEqual({ value: -1 })
+  })
+
+  it('should increment by amount', () => {
+    mockStore.dispatch(incrementByAmount(5))
+    expect(mockStore.dispatch.mock.calls[0][0].type).toEqual(incrementByAmount.type)
+    expect(mockStore.dispatch.mock.calls[0][0].payload).toEqual(5)
+    expect(mockStore.getReducerState()).toEqual({ value: 5 })
+  })
+})

--- a/examples/simpleSlice/reducer.ts
+++ b/examples/simpleSlice/reducer.ts
@@ -1,0 +1,28 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+type SimpleState = {
+  value: number
+}
+
+export const initialState: SimpleState = {
+  value: 0,
+}
+
+const simpleSlice = createSlice({
+  name: 'simpleSlice',
+  initialState,
+  reducers: {
+    increment: state => {
+      state.value += 1
+    },
+    decrement: state => {
+      state.value -= 1
+    },
+    incrementByAmount: (state, action: PayloadAction<number>) => {
+      state.value += action.payload
+    },
+  },
+})
+
+export const { increment, decrement, incrementByAmount } = simpleSlice.actions
+export default simpleSlice.reducer

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
   },
   silent: true,
   testEnvironment: 'node',
+  testPathIgnorePatterns: ['examples'],
   transform: {
     '^.+.tsx?$': ['ts-jest', {}],
   },


### PR DESCRIPTION
## Description

Document rtk-mock-store usage and methods in README.md. Include examples of how rtk-mock-store can be used to test synchronous and asychronous actions.

closes #5 