### PR TITLE
fix/publish action for publishing github package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ run-name: ${{ github.actor }} is running publish workflow
 on:
   release:
     types: [published]
-concurrency: ${{ github.workflow }}-${{ github.ref}}
+concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   publish-npm:
     name: Publish to npm
@@ -41,6 +41,7 @@ jobs:
         with:
           node-version: '22.11.0'
           registry-url: 'https://npm.pkg.github.com'
+          scope: '@${{ github.repository_owner }}'
       - name: Install dependencies
         run: npm ci
       - name: Build


### PR DESCRIPTION
## Description

Current github action for publishing github package does not publish due to the package not being scoped by github username. Github packages must be scoped by user or organization in order to successfully publish the package.

## Commits

fix: add package scope to conform with github packages publish guidelines

